### PR TITLE
Fix docker-compose pull issue

### DIFF
--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -59,10 +59,10 @@
     mode: '0775'
 
 - name: Redis | Docker-compose pull
-  docker_compose:
-    project_src: "{{ redis__path }}"
-    pull: yes
-    state: present
+  shell: "docker-compose pull"
+  args:
+    chdir: "{{ redis__path }}"
+  changed_when: "'... pull complete' in result.stderr | default('')"
   tags:
     - download
 


### PR DESCRIPTION
Apparently, if you use the Ansible `docker-compose` module, it will automatically run docker-compose up after pulling images and starting the services which is not the expected behavior.
I used the old way of running docker-compose pull via shell.